### PR TITLE
gluon-config-mode:pubkey darf nicht leer sein

### DIFF
--- a/i18n/de.po
+++ b/i18n/de.po
@@ -17,6 +17,9 @@ msgstr ""
 
 msgid "gluon-config-mode:pubkey"
 msgstr ""
+"Der öffentliche VPN-Schlüssel deines Freifunk-Knotens muss bei uns nicht <br />"
+"auf den Servern des Freifunks Flensburg registriert werden <br /> <br />"
+"Dein Knoten ist sofort Einsatzbereit. <br />"
 
 
 msgid "gluon-config-mode:reboot"


### PR DESCRIPTION
sonst taucht am der Stelle die variable `gluon-config-mode:pubkey` im text auf