### PR TITLE
Mesh VPN: Allow user to switch to performance mode

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -53,6 +53,7 @@
 		enabled = true,
 		fastd = {
 		         methods = {'salsa2012+umac'},
+			 configurable = true,
 		         
 				groups={
 			        backbone = {


### PR DESCRIPTION
This commit adds a new Mesh VPN tab to the config mode and allows the user to switch between security mode and performance mode.

Security mode is enabled by default. The performance mode disables encyrption for fastd but since the wifi is unencrypted anyway and all security related services use https nowadays I don't see any risk in enabling it.

Attention: The "none" cipher needs to be added to fastds server method list otherwise switching to performance mode fails with "failed: sending error: no common methods are configured".

It's documented here: http://gluon.readthedocs.io/en/v2018.1.x/features/vpn.html